### PR TITLE
Fix RTX_TRACE check

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -2,7 +2,7 @@
 set -eu
 [ "${BASH_VERSINFO[0]}" -ge 3 ] && set -o pipefail
 
-[ "${RTX_TRACE:-}" -eq 1 ] && set -x
+[ "${RTX_TRACE:-}" == "1" ] && set -x
 
 PLUGIN_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
 


### PR DESCRIPTION
In bash, `-eq` represents numeric equality, which also validates that both sides of the equation are numbers. In the case of an empty string, this fails.

Using `==` instead will compare both sides as strings